### PR TITLE
Assist mic feature - snd response elsewhere

### DIFF
--- a/assist_microphone/DOCS.md
+++ b/assist_microphone/DOCS.md
@@ -56,6 +56,48 @@ Enables or disables output audio.
 
 Multiply sound output volume by fixed value (1.0 = no change, 2.0 = twice as loud). 1.0 is the default.
 
+### Option: `synthesize_using_webhook`
+
+When text-to-speech text is returned send it to a webhook. This feature does nothing entirely on its own. You will need to create an automation using the webhook platform trigger. Read the HA webhook automation trigger [documentation](https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger) for more information. 
+
+<details>
+<summary>Example Automation</summary>
+```yaml
+alias: Satellite response
+description: ""
+trigger:
+  - platform: webhook
+    allowed_methods:
+      - POST
+      - PUT
+    local_only: true
+    webhook_id: "synthesize-assist-microphone-response"
+condition: []
+action:
+  - service: telegram_bot.send_message
+    metadata: {}
+    data:
+      message: "{{ trigger.json.response }}"
+      title: Smarto
+  - service: tts.cloud_say
+    data:
+      entity_id: media_player.name
+      cache: false
+      message: "{{ trigger.json.response }}"
+mode: single
+```
+</details>
+
+If you're doing this, you probably aslo want to set `sound_enabled` to false.
+
+### Option: `webhook_id`
+
+The name of the webhook to use. This is only relevant if `synthesize_using_webhook` is true.
+
+### Option: `synthesize_script`
+
+The script that does the heavy lifting of sending the text you want to synthesize to the home assistant webhook. This is only relevant if `synthesize_using_webhook` is true.
+
 ### Option: `debug_logging`
 
 Enable debug logging.

--- a/assist_microphone/config.yaml
+++ b/assist_microphone/config.yaml
@@ -24,6 +24,9 @@ options:
   auto_gain: 0
   mic_volume_multiplier: 1.0
   sound_volume_multiplier: 1.0
+  synthesize_using_webhook: false
+  webhook_id: "synthesize-assist-microphone-response"
+  synthesize_script: "/usr/src/scripts/synthesize.sh"  
   debug_logging: false
 schema:
   awake_wav: str
@@ -36,6 +39,9 @@ schema:
   auto_gain: int
   mic_volume_multiplier: float
   sound_volume_multiplier: float
+  synthesize_using_webhook: bool
+  webhook_id: str
+  synthesize_script: str  
   debug_logging: bool
 audio: true
 homeassistant: 2023.12.1

--- a/assist_microphone/rootfs/etc/s6-overlay/s6-rc.d/assist_microphone/run
+++ b/assist_microphone/rootfs/etc/s6-overlay/s6-rc.d/assist_microphone/run
@@ -26,4 +26,7 @@ exec python3 -m wyoming_satellite \
     --snd-volume-multiplier "$(bashio::config 'sound_volume_multiplier')" \
     --mic-auto-gain "$(bashio::config 'auto_gain')" \
     --mic-noise-suppression "$(bashio::config 'noise_suppression')" \
+    if bashio::config.true 'synthesize_using_webhook'; then
+        extra_args+=("--synthesize-command" "$(bashio::config 'synthesize_script')")
+    fi
     --no-zeroconf "${extra_args[@]}"

--- a/assist_microphone/rootfs/etc/s6-overlay/s6-rc.d/assist_microphone/run
+++ b/assist_microphone/rootfs/etc/s6-overlay/s6-rc.d/assist_microphone/run
@@ -13,6 +13,10 @@ if bashio::config.true 'sound_enabled'; then
     extra_args+=('--snd-command' 'aplay -r 16000 -c 1 -f S16_LE -t raw')
 fi
 
+if bashio::config.true 'synthesize_using_webhook'; then
+    extra_args+=("--synthesize-command" "$(bashio::config 'synthesize_script')")
+fi
+
 exec python3 -m wyoming_satellite \
     --name 'assist microphone' \
     --uri 'tcp://0.0.0.0:10700' \
@@ -26,7 +30,4 @@ exec python3 -m wyoming_satellite \
     --snd-volume-multiplier "$(bashio::config 'sound_volume_multiplier')" \
     --mic-auto-gain "$(bashio::config 'auto_gain')" \
     --mic-noise-suppression "$(bashio::config 'noise_suppression')" \
-    if bashio::config.true 'synthesize_using_webhook'; then
-        extra_args+=("--synthesize-command" "$(bashio::config 'synthesize_script')")
-    fi
     --no-zeroconf "${extra_args[@]}"

--- a/assist_microphone/scripts/synthesize.sh
+++ b/assist_microphone/scripts/synthesize.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash
+#!/command/with-contenv bashio
+# vim: ft=bash
+# shellcheck shell=bash
+# ==============================================================================
 
 ###
 # This script is used to send text to a Home Assistant webhook.

--- a/assist_microphone/scripts/synthesize.sh
+++ b/assist_microphone/scripts/synthesize.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+###
+# This script is used to send text to a Home Assistant webhook.
+#
+# It is intended to be used within the context of a wyoming-satellite
+# --synthesize-command when text-to-speech text is returned on stdin.
+#
+# Author: https://github.com/AlfredJKwack
+###
+
+set -e
+
+# Take text on stdin and JSON-encode it
+text="$(cat | jq -R -s '.')"
+
+# Set the default webhook name if not set in the configuration
+if bashio::var.has_value "$(bashio::config 'webhook_id')"; then
+  webhook_id="$(bashio::config 'webhook_id')"
+else
+  bashio::log.warning  "webhook_id is not set. Will set to default"
+  webhook_id="synthesize-assist-microphone-response"
+fi
+bashio::log.debug  "webhook_id is set to : $(bashio::config 'webhook_id')"
+
+# Check if SUPERVISOR_TOKEN is set
+if [ -z "$SUPERVISOR_TOKEN" ]; then
+    bashio::log.error "SUPERVISOR_TOKEN is not set. Exiting."
+    exit 1
+fi
+
+# Get the IPv4 address from the first Home Assistant interface
+ha_ip=$(curl -s -X GET \
+    -H "Authorization: Bearer $SUPERVISOR_TOKEN" \
+    http://supervisor/network/info \
+  | jq -r '.data.interfaces[0].ipv4.address[0]' \
+  | cut -d'/' -f1)
+if [ -z "$ha_ip" ]; then
+  bashio::log.error "Failed to get Home Assistant IPv4 address."
+  exit 1
+fi  
+bashio::log.debug  "Home Assistant IPv4 : $ha_ip"
+
+# Determine if the HA host has SSL enabled.
+ssl_enabled=$(curl -s -X GET \
+  -H "Authorization: Bearer $SUPERVISOR_TOKEN" \
+  http://supervisor/homeassistant/info \
+  | jq -r '.data.ssl')
+if [ -z "$ssl_enabled" ]; then
+  bashio::log.error "Failed to determine if SSL is enabled."
+  exit 1
+fi  
+bashio::log.debug "Home Assistant SSL enabled : $ssl_enabled"
+
+# Construct webhook URL based on SSL state, IP and webhook
+if [[ "$ssl_enabled" == "true" ]]; then
+  webhookurl="https://${ha_ip}:8123/api/webhook/${webhook_id}"
+else
+  webhookurl="http://${ha_ip}:8123/api/webhook/${webhook_id}"
+fi
+bashio::log.debug  "webhookurl set to : $webhookurl"
+
+# Send the text to the Home Assistant Webhook.
+bashio::log.debug "Text to speech text: ${text} to $webhookurl"
+json_payload="{\"response\": ${text}}"
+bashio::log.debug "Payload: ${json_payload}"
+response=$(curl -s -o /dev/null -w "%{http_code}" -k -X POST \
+  -H "Content-Type: application/json" \
+  -d "$json_payload" \
+  "${webhookurl}")
+if [ "$response" -ne 200 ]; then
+  bashio::log.error "Failed to send text to webhook. HTTP status code: $response"
+  exit 1
+fi
+bashio::log.debug "Successfully sent text to webhook."

--- a/assist_microphone/translations/en.yaml
+++ b/assist_microphone/translations/en.yaml
@@ -44,6 +44,18 @@ configuration:
     description: >-
       Multiply sound output volume by fixed value (1.0 = no change, 2.0 = twice
       as loud). 1.0 is the default.
+  synthesize_using_webhook:
+    name: Use webhook
+    description: >-
+      When text-to-speech text is returned send it to a webhook.
+  webhook_id:
+    name: Webhook ID
+    description: >-
+      The ID of the webhook to use.
+  synthesize_script:
+    name: Synthesize script
+    description: >-
+      Path to the script that will doing the heavy lifting of sending the text to the webhook for further automation.
   debug_logging:
     name: Debug logging
     description: >-


### PR DESCRIPTION
**Objective:** 
Provide a means for the Wyoming Satellite audio to be piped elsewhere.

**Technical choices:**
- Use `--synthesize-command` offered by the upstream Wyoming Sattelite repo.
- Use HA's webhook API for flexibility (and to avoid generating long lived access tokens)

**Considersations, limitations and things**
- TTS is still getting processed. See upstream [wyoming-satellite PR #227](https://github.com/rhasspy/wyoming-satellite/pull/227) for how that may be adressed down the line.
- This won't send the `--awake-wav` and `--done-wav` to wherever you send the text to be synthesized to.

**Reference conversations:**
- [Send response from satellite somewhere else](https://community.home-assistant.io/t/send-response-from-satellite-somewhere-else/707273)
- [Output returned audio to SONOS speaker from usb microphone](https://community.home-assistant.io/t/output-returned-audio-to-sonos-speaker-from-usb-microphone/760935)
- [Reusing Google nest speakers for response, but with Assist microphones, TTS](https://community.home-assistant.io/t/reusing-google-nest-speakers-for-response-but-with-assist-microphones-tts/631524)